### PR TITLE
Fix an issue with Holder listening to the held object's disposal

### DIFF
--- a/test/lib/dispose2.ts
+++ b/test/lib/dispose2.ts
@@ -1,4 +1,4 @@
-import {Disposable} from '../../lib/dispose';
+import {Disposable, Holder} from '../../lib/dispose';
 
 import {assert} from 'chai';
 import noop = require('lodash/noop');
@@ -7,6 +7,10 @@ import {assertResetSingleCall, consoleCapture} from './testutil2';
 
 describe('dispose2', function() {
   const fooDisposed: sinon.SinonSpy = sinon.spy();
+
+  beforeEach(function() {
+    fooDisposed.resetHistory();
+  });
 
   class Foo extends Disposable {
     constructor(public a: number, callback: (owner: Disposable) => void) {
@@ -69,6 +73,76 @@ describe('dispose2', function() {
         foo.dispose();
         assert.deepEqual(messages, ["error: Error disposing Foo which is already disposed"]);
       });
+    });
+  });
+
+  describe("Holder", function() {
+    it("should dispose previously held object", function() {
+      const holder = Holder.create<Foo>(null);
+      assert.isTrue(holder.isEmpty());
+      assert.strictEqual(holder.get(), null);
+
+      const foo = Foo.create(holder, 17, noop);
+      assert.isFalse(holder.isEmpty());
+      sinon.assert.notCalled(fooDisposed);
+      assert.strictEqual(holder.get(), foo);
+
+      const bar = Foo.create(holder, 28, noop);
+      assert.isFalse(holder.isEmpty());
+      assertResetSingleCall(fooDisposed, foo);
+      assert.strictEqual(holder.get(), bar);
+      assert.strictEqual(holder.get()!.a, 28);
+
+      holder.clear();
+      assert.isTrue(holder.isEmpty());
+      assertResetSingleCall(fooDisposed, bar);
+      assert.strictEqual(holder.get(), null);
+
+      const baz = Foo.create(holder, 39, noop);
+      assert.isFalse(holder.isEmpty());
+      sinon.assert.notCalled(fooDisposed);
+      assert.strictEqual(holder.get(), baz);
+
+      holder.dispose();
+      assertResetSingleCall(fooDisposed, baz);
+    });
+
+    it("should notice when a Disposable gets disposed outside", function() {
+      const holder = Holder.create(null);
+      const foo = Foo.create(holder, 16, noop);
+      assert.strictEqual(holder.get(), foo);
+
+      foo.dispose();
+      assertResetSingleCall(fooDisposed, foo);
+      assert.isTrue(holder.isEmpty());
+      assert.strictEqual(holder.get(), null);
+
+      holder.clear();
+      sinon.assert.notCalled(fooDisposed);
+    });
+
+    it("should release fully when holding a Disposable", function() {
+      const holder = Holder.create(null);
+      const foo = Foo.create(holder, 16, noop);
+      assert.strictEqual(holder.get(), foo);
+
+      assert.strictEqual(holder.release(), foo);
+      assert.isTrue(holder.isEmpty());
+      assert.strictEqual(holder.get(), null);
+
+      const bar = Foo.create(holder, 27, noop);
+      assert.isFalse(holder.isEmpty());
+      assert.strictEqual(holder.get(), bar);
+
+      // Holder used to listen to foo's disposal, but it's been released, so foo's disposal should
+      // no longer affect the holder.
+      foo.dispose();
+      assertResetSingleCall(fooDisposed, foo);
+      assert.isFalse(holder.isEmpty());
+      assert.strictEqual(holder.get(), bar);
+
+      holder.dispose();
+      assertResetSingleCall(fooDisposed, bar);
     });
   });
 });


### PR DESCRIPTION
This fixes a subtle bug I found with grainjs's Holder. Holder owns a contained object, but also watches it in case the object gets disposed from outside. There was a bug where if the object is released, the Holder wouldn't stop watching it. This fixes it and adds tests.