### PR TITLE
Add dom.onKeyDown() and support bubbling-suppression in keyboard events 

### DIFF
--- a/lib/dom.ts
+++ b/lib/dom.ts
@@ -88,6 +88,7 @@ export namespace dom {      // tslint:disable-line:no-namespace
   export const on              = domevent.on;
   export const onMatchElem     = domevent.onMatchElem;
   export const onMatch         = domevent.onMatch;
-  export const onKeyPressElem  = domevent.onKeyPressElem;
+  export const onKeyPressElem  = domevent.onKeyElem;
   export const onKeyPress      = domevent.onKeyPress;
+  export const onKeyDown       = domevent.onKeyDown;
 }

--- a/test/lib/testutil2.ts
+++ b/test/lib/testutil2.ts
@@ -14,6 +14,10 @@ export function assertResetSingleCall(spy: sinon.SinonSpy, context: any, ...args
   spy.resetHistory();
 }
 
+export function assertResetSingleCallStrict(spy: sinon.SinonSpy, context: any, ...args: any[]): void {
+  assertResetSingleCall(spy, context, ...args.map((a) => sinon.match.same(a)));
+}
+
 /**
  * Assert the list of first args with which the given spy was called; then resets its history.
  */

--- a/test/types/subscribe.ts
+++ b/test/types/subscribe.ts
@@ -1,0 +1,54 @@
+import { computed, Computed } from '../../lib/computed';
+import { pureComputed, PureComputed } from '../../lib/pureComputed';
+import { observable, Observable } from '../../lib/observable';
+import { subscribe, Subscription } from '../../lib/subscribe';
+
+function foo(s: string, n: number): string { return ''; }
+
+const o1: Observable<number> = observable(1);
+const o2: Observable<string> = observable("2");
+const c1: Computed<number> = computed((use) => 2 * use(o1));
+const c2: Computed<string> = computed(o1, o2, (use, _o1, _o2) => foo(_o2, _o1) + foo(use(o2), use(o1)));
+const p1: PureComputed<number> = pureComputed((use) => 2 * use(o1));
+const p2: PureComputed<string> = pureComputed(o1, o2, (use, _o1, _o2) => foo(_o2, _o1) + foo(use(o2), use(o1)));
+const s1: Subscription = subscribe((use) => console.log(2 * use(o1)));
+const s2: Subscription = subscribe(o1, o2, (use, _o1, _o2) => console.log(foo(_o2, _o1), foo(use(o2), use(o1))));
+
+[c1, c2, p1, p2, s1, s2];     // Silence unused-variable errors.
+
+computed(o1, o2, (use, _o1, _o2) => {
+  _o1;        // $ExpectType number
+  _o2;        // $ExpectType string
+  use(o1);    // $ExpectType number
+  use(o2);    // $ExpectType string
+  use;        // $ExpectType UseCB
+});
+
+pureComputed(o1, o2, (use, _o1, _o2) => {
+  _o1;        // $ExpectType number
+  _o2;        // $ExpectType string
+  use(o1);    // $ExpectType number
+  use(o2);    // $ExpectType string
+  use;        // $ExpectType UseCB
+});
+
+subscribe(o1, o2, (use, _o1, _o2) => {
+  _o1;        // $ExpectType number
+  _o2;        // $ExpectType string
+  use(o1);    // $ExpectType number
+  use(o2);    // $ExpectType string
+  use;        // $ExpectType UseCB
+});
+
+// Should support up to 5 static dependencies. We are not using generics here only because
+// var-args can't be used when they are not the last argument.
+computed(o1, o2, o1, o2, o1, (use, _o1, _o2, _o1b, _o2b, _o1c) => {
+  _o1;        // $ExpectType number
+  _o2;        // $ExpectType string
+  _o1b;       // $ExpectType number
+  _o2b;       // $ExpectType string
+  _o1c;       // $ExpectType number
+  use(o1);    // $ExpectType number
+  use(o2);    // $ExpectType string
+  use;        // $ExpectType UseCB
+});


### PR DESCRIPTION
This moves the version of onKeyDown() from weasel.js to grainjs, and extends onKeyPress() to support the same convention (`{Enter: () => ...}` stops the event from bubbling, `{Enter$: () => ...}` allows it to bubble). Includes a test, and also an unrelated extra typings test.