### PR TITLE
Styled elements should return type HTMLElement rather than just Element

### DIFF
--- a/lib/styled.ts
+++ b/lib/styled.ts
@@ -85,7 +85,7 @@ export interface IClsName {
 }
 
 // See module documentation for details.
-export function styled<R>(tag: string, styles: string): DomCreateFunc0<Element> & IClsName;
+export function styled<R>(tag: string, styles: string): DomCreateFunc0<HTMLElement> & IClsName;
 export function styled<R>(creator: DomCreateFunc0<R>, styles: string): DomCreateFunc0<R> & IClsName;
 export function styled<R, T>(creator: DomCreateFunc1<R, T>, styles: string): DomCreateFunc1<R, T> & IClsName;
 export function styled<R, T, U>(


### PR DESCRIPTION
Since `dom('div')` returns an HTMLElement, it makes more sense for `styled('div', ...)` to also produce HTMLElement rather than just Element. This saves some type-casting in other code.