### PR TITLE
Fix binding when used with BaseObservable.

### DIFF
--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -7,10 +7,10 @@ import {computed} from './computed';
 import {IDisposable} from './dispose';
 import {autoDisposeElem} from './domDispose';
 import {IKnockoutReadObservable} from './kowrap';
-import {Observable} from './observable';
+import {BaseObservable} from './observable';
 import {subscribe, UseCBOwner} from './subscribe';
 
-export type BindableValue<T> = Observable<T> | ComputedCallback<T> | T | IKnockoutReadObservable<T>;
+export type BindableValue<T> = BaseObservable<T> | ComputedCallback<T> | T | IKnockoutReadObservable<T>;
 
 export type ComputedCallback<T> = (use: UseCBOwner, ...args: any[]) => T;
 
@@ -48,7 +48,7 @@ export function subscribeBindable<T>(valueObs: BindableValue<T>,
   }
 
   // An observable.
-  if (valueObs instanceof Observable) {
+  if (valueObs instanceof BaseObservable) {
     // Use subscribe() rather than addListener(), so that bundling of changes (implicit and with
     // bundleChanges()) is respected. This matters when callback also uses observables.
     return subscribe(valueObs, (use, val) => callback(val));

--- a/lib/kowrap.ts
+++ b/lib/kowrap.ts
@@ -23,7 +23,7 @@
  * the returned wrapper should not be disposed; it's tied to the lifetime of the wrapped object.
  */
 
-import {BaseObservable, bundleChanges, Observable} from './observable';
+import {bundleChanges, Observable} from './observable';
 
 // Implementation note. Both wrappers are implemented in the same way.
 //
@@ -43,7 +43,7 @@ export interface IKnockoutReadObservable<T> {
   getSubscriptionsCount(): number;
 }
 
-const fromKoWrappers: WeakMap<IKnockoutObservable<any>, BaseObservable<any>> = new WeakMap();
+const fromKoWrappers: WeakMap<IKnockoutObservable<any>, Observable<any>> = new WeakMap();
 const toKoWrappers: WeakMap<Observable<any>, IKnockoutObservable<any>> = new WeakMap();
 
 /**
@@ -53,7 +53,7 @@ const toKoWrappers: WeakMap<Observable<any>, IKnockoutObservable<any>> = new Wea
  * to the lifetime of koObs. If unused, it consumes minimal resources, and should get garbage
  * collected along with koObs.
  */
-export function fromKo<T>(koObs: IKnockoutObservable<T>): BaseObservable<T> {
+export function fromKo<T>(koObs: IKnockoutObservable<T>): Observable<T> {
   return fromKoWrappers.get(koObs) || fromKoWrappers.set(koObs, new KoWrapObs(koObs)).get(koObs)!;
 }
 
@@ -64,7 +64,7 @@ export function fromKo<T>(koObs: IKnockoutObservable<T>): BaseObservable<T> {
  * This way, when unused, the only reference is from the wrapper to the wrapped object. KoWrapObs
  * should not be disposed; its lifetime is tied to that of the wrapped object.
  */
-export class KoWrapObs<T> extends BaseObservable<T> {
+export class KoWrapObs<T> extends Observable<T> {
   private _koSub: any = null;
 
   constructor(private _koObs: IKnockoutObservable<T>) {

--- a/test/lib/kowrap.ts
+++ b/test/lib/kowrap.ts
@@ -1,8 +1,8 @@
 import {assert} from 'chai';
 import * as ko from 'knockout';
 import * as sinon from 'sinon';
-import {bundleChanges, computed, fromKo, IKnockoutObservable, observable, pureComputed, toKo} from '../../index';
-import {assertResetSingleCall} from './testutil2';
+import {bundleChanges, computed, dom, fromKo, IKnockoutObservable, observable, pureComputed, toKo} from '../../index';
+import {assertResetSingleCall, useJsDomWindow} from './testutil2';
 
 describe('kowrap', function() {
 
@@ -265,4 +265,18 @@ describe('kowrap', function() {
     sinon.assert.notCalled(spyB2);
   });
 
+  describe("dom", function() {
+    useJsDomWindow();
+
+    it('should play well with dom bindings', function() {
+      const kObs = ko.observable(17);
+      const gObs = observable(17); // fromKo(kObs);
+      const elem = dom('input', dom.prop('value', gObs)) as HTMLInputElement;
+      assert.equal(elem.value, '17');
+      gObs.set(20);
+      assert.equal(elem.value, '20');
+      kObs(25);
+      assert.equal(elem.value, '20');
+    });
+  });
 });


### PR DESCRIPTION
Also restore fromKo to returning an Observable, which doesn't change
behavior but makes types simpler to use.