### PR TITLE
Fix type inference for knockout 3.5, and fix dom.onKeyElem export.

### DIFF
--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -6,7 +6,7 @@
 import {computed} from './computed';
 import {IDisposable} from './dispose';
 import {autoDisposeElem} from './domDispose';
-import {IKnockoutReadObservable} from './kowrap';
+import {IKnockoutReadObservable, InferKoType} from './kowrap';
 import {BaseObservable} from './observable';
 import {subscribe, UseCBOwner} from './subscribe';
 
@@ -25,8 +25,13 @@ export type ComputedCallback<T> = (use: UseCBOwner, ...args: any[]) => T;
  *
  * Returns an object which should be disposed to remove the created subscriptions, or null.
  */
-export function subscribeBindable<T>(valueObs: BindableValue<T>,
-                                     callback: (val: T) => void): IDisposable|null {
+// The overload below is annoying, but needed for correct type inference; see test/types/kowrap.ts.
+export function subscribeBindable<KObs extends IKnockoutReadObservable<any>>(
+    valueObs: KObs, callback: (val: InferKoType<KObs>) => void): IDisposable|null;
+export function subscribeBindable<T>(
+    valueObs: BindableValue<T>, callback: (val: T) => void): IDisposable|null;
+export function subscribeBindable<T>(
+    valueObs: BindableValue<T>, callback: (val: T) => void): IDisposable|null {
   // A plain function (to make a computed from), or a knockout observable.
   if (typeof valueObs === 'function') {
     // Knockout observable.

--- a/lib/dom.ts
+++ b/lib/dom.ts
@@ -91,7 +91,7 @@ export namespace dom {      // tslint:disable-line:no-namespace
   export const on              = domevent.on;
   export const onMatchElem     = domevent.onMatchElem;
   export const onMatch         = domevent.onMatch;
-  export const onKeyPressElem  = domevent.onKeyElem;
+  export const onKeyElem       = domevent.onKeyElem;
   export const onKeyPress      = domevent.onKeyPress;
   export const onKeyDown       = domevent.onKeyDown;
 }

--- a/lib/kowrap.ts
+++ b/lib/kowrap.ts
@@ -44,6 +44,12 @@ export interface IKnockoutReadObservable<T> {
   getSubscriptionsCount(): number;
 }
 
+// Inference from Knockout observable gets very tricky because ko.Observable includes the function
+// signature `(val: T) => any` from which type `any` gets inferred. We can infer the correct type
+// with this helper.
+export type InferKoType<KObs extends IKnockoutReadObservable<any>> =
+  KObs extends {peek(): infer T} ? T : never;
+
 const fromKoWrappers: WeakMap<IKnockoutObservable<any>, Observable<any>> = new WeakMap();
 const toKoWrappers: WeakMap<Observable<any>, IKnockoutObservable<any>> = new WeakMap();
 
@@ -54,7 +60,7 @@ const toKoWrappers: WeakMap<Observable<any>, IKnockoutObservable<any>> = new Wea
  * to the lifetime of koObs. If unused, it consumes minimal resources, and should get garbage
  * collected along with koObs.
  */
-export function fromKo<T>(koObs: IKnockoutObservable<T>): Observable<T> {
+export function fromKo<KObs extends IKnockoutObservable<any>>(koObs: KObs): Observable<InferKoType<KObs>> {
   return fromKoWrappers.get(koObs) || fromKoWrappers.set(koObs, new KoWrapObs(koObs)).get(koObs)!;
 }
 

--- a/lib/subscribe.ts
+++ b/lib/subscribe.ts
@@ -32,11 +32,16 @@ export interface ISubscribableObs {
 
 export type ISubscribable = ISubscribableObs | IKnockoutReadObservable<any>;
 
-// The generic type for the use() function that callbacks get.
-export type UseCB = <T>(obs: Obs<T>|IKnockoutReadObservable<T>) => T;
+// Type inference from the simpler Obs<T>|IKnockoutReadObservable<T> does not always produce
+// correct T for ko.Observable. The formula below is a workaround. See also InferKoType in kowrap.
+export type InferUseType<TObs extends Obs<any>|IKnockoutReadObservable<any>> =
+  TObs extends Obs<infer T> ? T :
+  TObs extends {peek(): infer U} ? U : never;
 
-export interface UseCBOwner {    // tslint:disable-line:interface-name
-  <U>(obs: Obs<U>|IKnockoutReadObservable<U>): U;
+// The generic type for the use() function that callbacks get.
+export type UseCB = <TObs extends Obs<any>|IKnockoutReadObservable<any>>(obs: TObs) => InferUseType<TObs>;
+
+export interface UseCBOwner extends UseCB {    // tslint:disable-line:interface-name
   owner: IDisposableOwner;
 }
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "fastpriorityqueue": "^0.6.1",
     "geckodriver": "^1.11.0",
     "jsdom": "15.0.0",
-    "knockout": "^3.4.2",
+    "knockout": "^3.5.0",
     "lodash": "^4.17.4",
     "mocha": "^6.1.4",
     "mocha-webdriver": "^0.1.13",

--- a/test/types/README.md
+++ b/test/types/README.md
@@ -1,0 +1,8 @@
+## Testing Types
+
+This directory contains test of TypeScript typings, to ensure they allow correct constructs and
+disallow incorrect ones, and provide helpful type inference.
+
+The tool used for testing typings is [dtslint](https://github.com/microsoft/dtslint). See
+https://hackernoon.com/testing-types-an-introduction-to-dtslint-b178f9b18ac8 for an introduction
+on using dtslint for testing types.

--- a/test/types/computed.ts
+++ b/test/types/computed.ts
@@ -1,3 +1,6 @@
+/**
+ * Test types using dtslint. See README in this directory.
+ */
 import { Computed, Holder, Observable } from '../../index';
 
 function foo(s: string, n: number): string { return ''; }

--- a/test/types/dispose.ts
+++ b/test/types/dispose.ts
@@ -1,3 +1,6 @@
+/**
+ * Test types using dtslint. See README in this directory.
+ */
 import { Disposable, IDisposable, IDisposableCtor, IDisposableOwnerT } from '../../lib/dispose';
 
 class MyFoo extends Disposable {

--- a/test/types/dom.ts
+++ b/test/types/dom.ts
@@ -1,3 +1,6 @@
+/**
+ * Test types using dtslint. See README in this directory.
+ */
 import { dom, DomArg, DomElementArg } from '../../lib/dom';
 
 dom('div', dom.text('hello'));    // $ExpectType HTMLDivElement

--- a/test/types/domComponent.ts
+++ b/test/types/domComponent.ts
@@ -1,3 +1,6 @@
+/**
+ * Test types using dtslint. See README in this directory.
+ */
 import { Disposable, dom, IDisposableOwner } from '../../index';
 
 class MyComp extends Disposable {

--- a/test/types/domComputed.ts
+++ b/test/types/domComputed.ts
@@ -1,3 +1,6 @@
+/**
+ * Test types using dtslint. See README in this directory.
+ */
 import { observable } from '../../lib/observable';
 import { dom } from '../../lib/dom';
 

--- a/test/types/kowrap.ts
+++ b/test/types/kowrap.ts
@@ -1,0 +1,39 @@
+import { BindableValue, Computed, fromKo, Observable, subscribe, subscribeBindable, toKo } from '../../index';
+import * as ko from 'knockout';
+
+const kObs = ko.observable("foo");
+const gObs = Observable.create(null, "foo");
+
+// Check that inference works for fromKo().
+fromKo(kObs);                                 // $ExpectType Observable<string>
+
+// Check that inference works for toKo().
+toKo(ko, gObs);                               // $ExpectType IKnockoutObservable<string>
+
+// Check that inference works for use() in a Computed callback.
+Computed.create(null, (use) =>                // $ExpectType Computed<string>
+  use(kObs));                                 // $ExpectType string
+Computed.create(null, (use) =>                // $ExpectType Computed<string>
+  use(gObs));                                 // $ExpectType string
+
+// Check that inference works for use() in a subscribe callback.
+subscribe((use) =>
+  use(kObs));                                 // $ExpectType string
+subscribe((use) =>
+  use(gObs));                                 // $ExpectType string
+
+// Check that inference from knockout types works for bindings.
+subscribeBindable(kObs, (val) =>
+  val);                                       // $ExpectType string
+
+// Check that knockout typings don't interfere with other type inference for BindableValue.
+const bindable: BindableValue<string> = kObs;
+subscribeBindable(bindable, (val) =>
+  val);                                       // $ExpectType string
+subscribeBindable(gObs, (val) =>
+  val);                                       // $ExpectType string
+subscribeBindable((use) => {
+  use;                                        // $ExpectType UseCBOwner
+  return "foo";
+}, (val) =>
+  val);                                       // $ExpectType string

--- a/test/types/kowrap.ts
+++ b/test/types/kowrap.ts
@@ -1,3 +1,6 @@
+/**
+ * Test types using dtslint. See README in this directory.
+ */
 import { BindableValue, Computed, fromKo, Observable, subscribe, subscribeBindable, toKo } from '../../index';
 import * as ko from 'knockout';
 

--- a/test/types/styled.ts
+++ b/test/types/styled.ts
@@ -1,6 +1,9 @@
-// This test verifies that styled() wrappers around DOM-building functions preserve useful type
-// info, and let it be inferred for their arguments.
-
+/**
+ * Test types using dtslint. See README in this directory.
+ *
+ * This test verifies that styled() wrappers around DOM-building functions preserve useful type
+ * info, and let it be inferred for their arguments.
+ */
 import { dom, DomElementArg, input, observable, styled } from '../../index';
 
 // Styled with a tag name should produce dom-creators with same arg types as DOM.

--- a/test/types/subscribe.ts
+++ b/test/types/subscribe.ts
@@ -1,3 +1,6 @@
+/**
+ * Test types using dtslint. See README in this directory.
+ */
 import { computed, Computed } from '../../lib/computed';
 import { pureComputed, PureComputed } from '../../lib/pureComputed';
 import { observable, Observable } from '../../lib/observable';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3685,7 +3685,7 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
-knockout@^3.4.2:
+knockout@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/knockout/-/knockout-3.5.0.tgz#6d3e19bf53b1dc4d8de81c97a5ba9672443dc292"
   integrity sha512-vBUF/IsBDzaejHkNpiquKdc5uPrImXuQ4Mb9lEfNNJ5cyHGI8ThDupR+h3eMFZhfmPE/brfwcIAn/fm0yOvJUg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2568,9 +2568,9 @@ fstream-ignore@^1.0.5:
     minimatch "^3.0.0"
 
 fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
-  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
   dependencies:
     graceful-fs "^4.1.2"
     inherits "~2.0.0"


### PR DESCRIPTION
- dom.onKeyElem was confusingly renamed on export (a typo)
- Ensure we use knockout 3.5 (as dev dependency)
- Type inference for ko.Observable was still poor; this adds a typings test for it, and includes changes to make it pass.