### PR TITLE
Add domComputedOwned/maybeOwned methods, which add an owner argument.

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -118,7 +118,7 @@ Returns the value associated with a DOM element using `dom.data()`
 
 ### dom.maybe _(dom-method)_
 ```typescript
-dom.maybe<T>(boolValue: BindableValue<T>, contentFunc: (val: NonNullable<T>) => DomArg)
+dom.maybe<T>(boolValue: BindableValue<T>, contentFunc: (val: NonNullable<T>) => DomContents)
 ```
 
 Conditionally appends DOM to an element. The value may be an observable or function (from which a
@@ -137,9 +137,18 @@ simpler.
 * `dom(..., dom.maybe(myValue, () => dom(...)));`
 * `dom(..., myValue ? dom(...) : null);`
 
+### dom.maybeOwned _(dom-method)_
+```typescript
+dom.maybeOwned<T>(boolValue: BindableValue<T>, contentFunc: (owner: MultiHolder, val: NonNullable<T>) => DomContents)
+```
+
+Like `dom.maybe()`, but the callback gets an additional first argument `owner`, which may be used
+to take ownership of objects created by the callback. These will be disposed before each new call
+to the callback, and when the condition becomes false or the containing DOM gets disposed.
+
 ### dom.domComputed _(dom-method)_
 ```typescript
-dom.domComputed<T>(value: BindableValue<T>, contentFunc: (val: T) => DomArg)
+dom.domComputed<T>(value: BindableValue<T>, contentFunc: (val: T) => DomContents)
 dom.domComputed(value: BindableValue<Node>)
 ```
 
@@ -172,6 +181,15 @@ If the argument is not an observable, dom.domComputed() may still be used, but i
 
 * `dom(..., dom.domComputed(nlines, n => (n > 1) ? dom('textarea') : dom('input')));`
 * `dom(..., (nlines > 1) ? dom('textarea') : dom('input'));`
+
+### dom.domComputedOwned _(dom-method)_
+```typescript
+dom.domComputedOwned<T>(value: BindableValue<T>, contentFunc: (owner: MultiHolder, val: T) => DomContents)
+```
+
+Like `dom.domComputed()`, but the callback gets an additional first argument `owner`, which may be
+used to take ownership of objects created by the callback. These will be disposed before each new
+call to the callback, and when the containing DOM is disposed.
 
 ### dom.forEach _(dom-method)_
 ```typescript

--- a/lib/dom.ts
+++ b/lib/dom.ts
@@ -81,7 +81,9 @@ export namespace dom {      // tslint:disable-line:no-namespace
   export const getData         = _domMethods.getData;
   export const replaceContent  = _domComputed.replaceContent;
   export const domComputed     = _domComputed.domComputed;
+  export const domComputedOwned = _domComputed.domComputedOwned;
   export const maybe           = _domComputed.maybe;
+  export const maybeOwned      = _domComputed.maybeOwned;
 
   export const forEach         = _domForEach.forEach;
 

--- a/lib/domForEach.ts
+++ b/lib/domForEach.ts
@@ -1,6 +1,6 @@
-import {replaceContent} from './domComputed';
+import {DomContents, replaceContent} from './domComputed';
 import {autoDisposeElem, domDispose} from './domDispose';
-import {DomMethod, frag} from './domImpl';
+import {frag} from './domImpl';
 import {computedArray, MaybeObsArray, ObsArray} from './obsArray';
 
 // Use the browser globals in a way that allows replacing them with mocks in tests.
@@ -24,13 +24,10 @@ import {G} from './browserGlobals';
  * If you'd like to map the DOM node back to its source item, use dom.data() and dom.getData() in
  * itemCreateFunc().
  */
-export function forEach<T>(obsArray: MaybeObsArray<T>, itemCreateFunc: (item: T) => Node|null): DomMethod {
-  return (elem: Node) => {
-    const markerPre = G.document.createComment('a');
-    const markerPost = G.document.createComment('b');
-    elem.appendChild(markerPre);
-    elem.appendChild(markerPost);
-
+export function forEach<T>(obsArray: MaybeObsArray<T>, itemCreateFunc: (item: T) => Node|null): DomContents {
+  const markerPre = G.document.createComment('a');
+  const markerPost = G.document.createComment('b');
+  return [markerPre, markerPost, (elem: Node) => {
     if (Array.isArray(obsArray)) {
       replaceContent(markerPre, markerPost, obsArray.map(itemCreateFunc));
       return;
@@ -72,5 +69,5 @@ export function forEach<T>(obsArray: MaybeObsArray<T>, itemCreateFunc: (item: T)
       }
     });
     replaceContent(markerPre, markerPost, nodes.get());
-  };
+  }];
 }


### PR DESCRIPTION
Creating disposable objects inside of domComputed() and maybe() has been
awkward. These methods make it simple.

Includes a bit of simplification of domComponent, and tightening of
types for domComputed, maybe, and forEach. Includes a test case.