### PR TITLE
Fix typing of `dom.attr` helper to expose that null values are allowed

### DIFF
--- a/lib/domMethods.ts
+++ b/lib/domMethods.ts
@@ -34,16 +34,16 @@ export function attrs(attrsObj: IAttrObj): DomElementMethod {
  * observable or function.
  * @param {Element} elem: The element to update.
  * @param {String} attrName: The name of the attribute to bind, e.g. 'href'.
- * @param {String|null} attrValue: The string value or null to remove the attribute.
+ * @param {String|null|undefined} attrValue: The string value, or null or undefined to remove the attribute.
  */
-export function attrElem(elem: Element, attrName: string, attrValue: string|null): void {
+export function attrElem(elem: Element, attrName: string, attrValue: string|null|undefined): void {
   if (attrValue === null || attrValue === undefined) {
     elem.removeAttribute(attrName);
   } else {
     elem.setAttribute(attrName, attrValue);
   }
 }
-export function attr(attrName: string, attrValueObs: BindableValue<string>): DomElementMethod {
+export function attr(attrName: string, attrValueObs: BindableValue<string|null|undefined>): DomElementMethod {
   return (elem) => _subscribe(elem, attrValueObs, (val) => attrElem(elem, attrName, val));
 }
 

--- a/test/lib/dom.js
+++ b/test/lib/dom.js
@@ -221,6 +221,8 @@ describe('dom', function() {
                      dom.attr('a1', 'foo'),
                      dom.attr('a2', obs),
                      dom.attr('a3', use => "a3" + use(obs)),
+                     dom.attr('a4', use => use(obs) === 'bar' ? 'a4' : null),
+                     dom.attr('a5', use => use(obs) === 'bar' ? 'a5' : undefined),
                      dom.boolAttr('b1', obs),
                      dom.prop('value', use => "prop" + use(obs) + use(width)),
                      dom.text(obs),
@@ -233,6 +235,8 @@ describe('dom', function() {
       assert.equal(elem.getAttribute('a1'), 'foo');
       assert.equal(elem.getAttribute('a2'), 'bar');
       assert.equal(elem.getAttribute('a3'), 'a3bar');
+      assert.equal(elem.getAttribute('a4'), 'a4');
+      assert.equal(elem.getAttribute('a5'), 'a5');
       assert.equal(elem.getAttribute('b1'), '');
       assert.equal(elem.value, 'propbar17');
       assert.equal(elem.textContent, 'bar');
@@ -246,6 +250,8 @@ describe('dom', function() {
       assert.equal(elem.getAttribute('a1'), 'foo');
       assert.equal(elem.getAttribute('a2'), 'BAZ');
       assert.equal(elem.getAttribute('a3'), 'a3BAZ');
+      assert.equal(elem.getAttribute('a4'), null);
+      assert.equal(elem.getAttribute('a5'), null);
       assert.equal(elem.getAttribute('b1'), '');
       assert.equal(elem.value, 'propBAZ34');
       assert.equal(elem.textContent, 'BAZ');


### PR DESCRIPTION
Hey there :wave: 

The `dom.attr` and `dom.attrElem` helpers allow `null` and `undefined` values to remove the specified attribute. But the TS typings only allowed `string` observables.

It generated typing errors while the executed code had actually no issue.

I think just these changes are enough to prevent false errors?