### PR TITLE
Address a bug with computeds unexpectedly not getting updated.

### DIFF
--- a/lib/_computed_queue.ts
+++ b/lib/_computed_queue.ts
@@ -74,7 +74,7 @@ export class DepItem {
       if (this._isComputed) {
         computedQueue.push(this);
       } else {
-        otherQueue.push(this);
+        otherSubQueue.push(this);
       }
     }
   }
@@ -82,13 +82,14 @@ export class DepItem {
 
 // The main compute queue.
 const computedQueue = new PriorityQueue<DepItem>(DepItem.isPrioritySmaller);
-const otherQueue = new PriorityQueue<DepItem>(DepItem.isPrioritySmaller);
+const otherSubQueue = new PriorityQueue<DepItem>(DepItem.isPrioritySmaller);
 
 // Counter for creation order, used to create a stable ordering of DepItems at same priority.
 let _nextCreationNum = 0;
 
-// Counter used for bundling multiple calls to compute() into one.
+// Counters used for bundling multiple calls to compute() into one.
 let bundleDepth = 0;
+let otherSubBundleDepth = 0;
 
 /**
  * Exposed for unittests. Returns the internal priority value of an observable.
@@ -107,10 +108,20 @@ export function compute(): void {
   if (bundleDepth === 0) {
     if (computedQueue.size > 0) {
       // Prevent nested compute() calls, which are unnecessary and can cause deep recursion stack.
-      withBundleDepthIncrement(() => processQueue(computedQueue));
+      bundleDepth++;
+      try {
+        processQueue(computedQueue);
+      } finally {
+        bundleDepth--;
+      }
     }
-    if (otherQueue.size > 0) {
-      processQueue(otherQueue);
+    if (otherSubBundleDepth === 0 && otherSubQueue.size > 0) {
+      otherSubBundleDepth++;
+      try {
+        processQueue(otherSubQueue);
+      } finally {
+        otherSubBundleDepth--;
+      }
     }
   }
 }
@@ -145,17 +156,10 @@ function processQueue(queue: PriorityQueue<DepItem>) {
  */
 export function bundleChanges<T>(func: () => T): T {
   try {
-    return withBundleDepthIncrement(func);
-  } finally {
-    compute();
-  }
-}
-
-function withBundleDepthIncrement<T>(func: () => T): T {
-  try {
     bundleDepth++;
     return func();
   } finally {
     bundleDepth--;
+    compute();
   }
 }

--- a/lib/_computed_queue.ts
+++ b/lib/_computed_queue.ts
@@ -87,10 +87,6 @@ const otherQueue = new PriorityQueue<DepItem>(DepItem.isPrioritySmaller);
 // Counter for creation order, used to create a stable ordering of DepItems at same priority.
 let _nextCreationNum = 0;
 
-// Array to keep track of items recomputed during this call to compute(). It could be a local
-// variable in compute(), but is made global to minimize allocations.
-const _seen: any[] = [];
-
 // Counter used for bundling multiple calls to compute() into one.
 let bundleDepth = 0;
 
@@ -122,8 +118,9 @@ export function compute(): void {
 // Calls recompute for all items in the queue, preventing loops -- attempts to enqueue again during
 // computation will be ignored! Assumes the passsed-in queue is non-empty.
 function processQueue(queue: PriorityQueue<DepItem>) {
+  // Array to keep track of items recomputed during this call to compute().
+  const _seen: DepItem[] = [];
   try {
-    // We reuse _seen array to minimize allocations, but always leave it empty.
     do {
       const item = queue.pop()!;
       _seen.push(item);
@@ -133,9 +130,8 @@ function processQueue(queue: PriorityQueue<DepItem>) {
     // We delay the unsetting of _enqueued flag to here, to protect against infinite loops when
     // a change to a computed causes it to get enqueued again.
     for (const item of _seen) {
-      item._enqueued = false;
+      (item as any)._enqueued = false;
     }
-    _seen.length = 0;
   }
 }
 

--- a/lib/_computed_queue.ts
+++ b/lib/_computed_queue.ts
@@ -39,7 +39,7 @@ export class DepItem {
   /**
    * Callback should call depItem.useDep(dep) for each DepInput it depends on.
    */
-  constructor(callback: () => void, optContext?: object, isComputed = false) {
+  constructor(callback: () => void, optContext: object | undefined, isComputed: boolean) {
     this._isComputed = isComputed;
     this._callback = callback;
     this._context = optContext;

--- a/lib/_computed_queue.ts
+++ b/lib/_computed_queue.ts
@@ -27,6 +27,7 @@ export class DepItem {
     return a._priority < b._priority || (a._priority === b._priority && a._creation < b._creation);
   }
 
+  private readonly _isComputed: boolean = false;
   private _priority: number = 0;
   private _enqueued: boolean = false;
   private _callback: () => void;
@@ -38,7 +39,8 @@ export class DepItem {
   /**
    * Callback should call depItem.useDep(dep) for each DepInput it depends on.
    */
-  constructor(callback: () => void, optContext?: object) {
+  constructor(callback: () => void, optContext?: object, isComputed = false) {
+    this._isComputed = isComputed;
     this._callback = callback;
     this._context = optContext;
   }
@@ -48,6 +50,7 @@ export class DepItem {
    * item such as a plain observable, which does not itself depend on anything else).
    */
   public useDep(depItem: DepItem|null): void {
+    if (depItem && !depItem._isComputed) { throw new Error("Non-computed used as dependency"); }
     const p = depItem ? depItem._priority : 0;
     if (p >= this._priority) {
       this._priority = p + 1;
@@ -68,13 +71,18 @@ export class DepItem {
   public enqueue(): void {
     if (!this._enqueued) {
       this._enqueued = true;
-      queue.push(this);
+      if (this._isComputed) {
+        computedQueue.push(this);
+      } else {
+        otherQueue.push(this);
+      }
     }
   }
 }
 
 // The main compute queue.
-const queue = new PriorityQueue<DepItem>(DepItem.isPrioritySmaller);
+const computedQueue = new PriorityQueue<DepItem>(DepItem.isPrioritySmaller);
+const otherQueue = new PriorityQueue<DepItem>(DepItem.isPrioritySmaller);
 
 // Counter for creation order, used to create a stable ordering of DepItems at same priority.
 let _nextCreationNum = 0;
@@ -100,25 +108,34 @@ export function _getPriority(obs: any): number {
  * there should be no need to ever call this by users of the library.
  */
 export function compute(): void {
-  if (bundleDepth === 0 && queue.size > 0) {
-    // Prevent nested compute() calls, which are unnecessary and can cause deep recursion stack.
-    bundleDepth++;
-    try {
-      // We reuse _seen array to minimize allocations, but always leave it empty.
-      do {
-        const item = queue.pop()!;
-        _seen.push(item);
-        item.recompute();
-      } while (queue.size > 0);
-    } finally {
-      // We delay the unsetting of _enqueued flag to here, to protect against infinite loops when
-      // a change to a computed causes it to get enqueued again.
-      for (const item of _seen) {
-        item._enqueued = false;
-      }
-      _seen.length = 0;
-      bundleDepth--;
+  if (bundleDepth === 0) {
+    if (computedQueue.size > 0) {
+      // Prevent nested compute() calls, which are unnecessary and can cause deep recursion stack.
+      withBundleDepthIncrement(() => processQueue(computedQueue));
     }
+    if (otherQueue.size > 0) {
+      processQueue(otherQueue);
+    }
+  }
+}
+
+// Calls recompute for all items in the queue, preventing loops -- attempts to enqueue again during
+// computation will be ignored! Assumes the passsed-in queue is non-empty.
+function processQueue(queue: PriorityQueue<DepItem>) {
+  try {
+    // We reuse _seen array to minimize allocations, but always leave it empty.
+    do {
+      const item = queue.pop()!;
+      _seen.push(item);
+      item.recompute();
+    } while (queue.size > 0);
+  } finally {
+    // We delay the unsetting of _enqueued flag to here, to protect against infinite loops when
+    // a change to a computed causes it to get enqueued again.
+    for (const item of _seen) {
+      item._enqueued = false;
+    }
+    _seen.length = 0;
   }
 }
 
@@ -132,10 +149,17 @@ export function compute(): void {
  */
 export function bundleChanges<T>(func: () => T): T {
   try {
+    return withBundleDepthIncrement(func);
+  } finally {
+    compute();
+  }
+}
+
+function withBundleDepthIncrement<T>(func: () => T): T {
+  try {
     bundleDepth++;
     return func();
   } finally {
     bundleDepth--;
-    compute();
   }
 }

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -3,8 +3,8 @@
  * a plain value, or a function from which it builds a computed.
  */
 
-import {computed} from './computed';
-import {IDisposable} from './dispose';
+import {Computed} from './computed';
+import {IDisposable, MultiHolder} from './dispose';
 import {autoDisposeElem} from './domDispose';
 import {IKnockoutReadObservable, InferKoType} from './kowrap';
 import {BaseObservable} from './observable';
@@ -53,10 +53,11 @@ export function subscribeBindable<T>(
     //    let sub = subscribe(use => callback(valueObs(use)));
     // The difference is that when valueObs() evaluates to unchanged value, callback would be
     // called in the version above, but not in the version below.
-    const comp = computed(valueObs as ComputedCallback<T>);
-    comp.addListener((val) => callback(val));
-    callback(comp.get());
-    return comp;      // Disposing this will dispose its one listener.
+    // TODO Try doing with only a subscription
+    const owner = MultiHolder.create(null);
+    const comp = Computed.create(owner, valueObs as ComputedCallback<T>);
+    owner.autoDispose(subscribe(comp, (use, val) => callback(val)));
+    return owner;
   }
 
   // An observable.

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -3,12 +3,11 @@
  * a plain value, or a function from which it builds a computed.
  */
 
-import {Computed} from './computed';
-import {IDisposable, MultiHolder} from './dispose';
+import {IDisposable} from './dispose';
 import {autoDisposeElem} from './domDispose';
 import {IKnockoutReadObservable, InferKoType} from './kowrap';
 import {BaseObservable} from './observable';
-import {subscribe, UseCBOwner} from './subscribe';
+import {subscribe, UseCB} from './subscribe';
 
 /**
  * Any of the value types that DOM methods know how to subscribe to: a plain value (like a
@@ -19,7 +18,7 @@ import {subscribe, UseCBOwner} from './subscribe';
  */
 export type BindableValue<T> = BaseObservable<T> | ComputedCallback<T> | T | IKnockoutReadObservable<T>;
 
-export type ComputedCallback<T> = (use: UseCBOwner, ...args: any[]) => T;
+export type ComputedCallback<T> = (use: UseCB, ...args: any[]) => T;
 
 /**
  * Subscribes a callback to valueObs, which may be one a plain value, an observable, a knockout
@@ -49,15 +48,20 @@ export function subscribeBindable<T>(
       return sub;
     }
 
-    // Function from which to make a computed. Note that this is also reasonable:
+    // Function from which to make a computed. This is similar to creating a computed and
+    // subscribing to it, but with a single subsciption. This difference from this naive approach:
     //    let sub = subscribe(use => callback(valueObs(use)));
-    // The difference is that when valueObs() evaluates to unchanged value, callback would be
-    // called in the version above, but not in the version below.
-    // TODO Try doing with only a subscription
-    const owner = MultiHolder.create(null);
-    const comp = Computed.create(owner, valueObs as ComputedCallback<T>);
-    owner.autoDispose(subscribe(comp, (use, val) => callback(val)));
-    return owner;
+    // is that when valueObs() evaluates to unchanged value, we don't want the callback called, to
+    // match behavior of regular computeds.
+    const cb = valueObs as ComputedCallback<T>;
+    let _lastValue: unknown = undefined;
+    return subscribe(use => {
+      const value = cb(use);
+      if (value !== _lastValue) {
+        _lastValue = value;
+        callback(value);
+      }
+    });
   }
 
   // An observable.

--- a/lib/computed.ts
+++ b/lib/computed.ts
@@ -97,7 +97,7 @@ export class Computed<T> extends Observable<T> {
     super(undefined as any);
     this._callback = callback;
     this._write = _noWrite;
-    this._sub = new Subscription(this._read.bind(this), dependencies, this);
+    this._sub = new Subscription(this._read.bind(this), dependencies, this, true);
   }
 
   /**

--- a/lib/pureComputed.ts
+++ b/lib/pureComputed.ts
@@ -101,7 +101,7 @@ export class PureComputed<T> extends Observable<T> {
 
   private _activate(): void {
     if (!this._sub) {
-      this._sub = new Subscription(this._read.bind(this), this._dependencies);
+      this._sub = new Subscription(this._read.bind(this), this._dependencies, this, true);
     }
   }
 

--- a/lib/subscribe.ts
+++ b/lib/subscribe.ts
@@ -69,8 +69,11 @@ export class Subscription {
   // Internal constructor for a Subscription. You should use subscribe() function instead.
   // The last owner argument is used by computed() to make itself available as the .owner property
   // of the 'use' function that gets passed to the callback.
-  constructor(callback: (use: UseCB, ...args: any[]) => void, dependencies: ReadonlyArray<ISubscribable>, owner?: any) {
-    this._depItem = new DepItem(this._evaluate, this);
+  constructor(
+    callback: (use: UseCB, ...args: any[]) => void, dependencies: ReadonlyArray<ISubscribable>,
+    owner?: any, isComputed = false,
+  ) {
+    this._depItem = new DepItem(this._evaluate, this, isComputed);
     this._dependencies = dependencies.length > 0 ? dependencies : emptyArray;
     this._depListeners = dependencies.length > 0 ? dependencies.map((obs) => this._subscribeTo(obs)) : emptyArray;
     this._dynDeps = new Map();   // Maps dependent observable to its Listener object.

--- a/test/lib/domComponent.ts
+++ b/test/lib/domComponent.ts
@@ -274,8 +274,8 @@ describe('domComponent', function() {
       '<!--a--><!--a--><div>Hola!4baz</div><!--b--><!--b-->' +
       '<!--b--></div>');
 
-    assert.equal(spies1.describeReset(), '-[world1FOO] +[Hola!1FOO,Hola!1baz] R[Hola!1baz]');
-    assert.equal(spies2.describeReset(), '-[world2FOO] +[Hola!2FOO,Hola!2baz] R[Hola!2baz]');
+    assert.equal(spies1.describeReset(), '-[world1FOO] +[Hola!1baz] R[Hola!1baz]');
+    assert.equal(spies2.describeReset(), '-[world2FOO] +[Hola!2baz] R[Hola!2baz]');
     assert.equal(spies3.describeReset(), '-[world3FOO] +[Hola!3foo,Hola!3FOO,Hola!3baz] R[Hola!3baz]');
     assert.equal(spies4.describeReset(), '-[world4FOO] +[Hola!4FOO,Hola!4baz] R[Hola!4baz]');
 

--- a/test/lib/domComponent.ts
+++ b/test/lib/domComponent.ts
@@ -274,10 +274,10 @@ describe('domComponent', function() {
       '<!--a--><!--a--><div>Hola!4baz</div><!--b--><!--b-->' +
       '<!--b--></div>');
 
-    assert.equal(spies1.describeReset(), '-[world1FOO] +[Hola!1baz] R[Hola!1baz]');
-    assert.equal(spies2.describeReset(), '-[world2FOO] +[Hola!2baz] R[Hola!2baz]');
-    assert.equal(spies3.describeReset(), '-[world3FOO] +[Hola!3baz,Hola!3foo,Hola!3FOO] R[Hola!3baz]');
-    assert.equal(spies4.describeReset(), '-[world4FOO] +[Hola!4baz] R[Hola!4baz]');
+    assert.equal(spies1.describeReset(), '-[world1FOO] +[Hola!1FOO,Hola!1baz] R[Hola!1baz]');
+    assert.equal(spies2.describeReset(), '-[world2FOO] +[Hola!2FOO,Hola!2baz] R[Hola!2baz]');
+    assert.equal(spies3.describeReset(), '-[world3FOO] +[Hola!3foo,Hola!3FOO,Hola!3baz] R[Hola!3baz]');
+    assert.equal(spies4.describeReset(), '-[world4FOO] +[Hola!4FOO,Hola!4baz] R[Hola!4baz]');
 
     obsInner.set('xxx');
     assert.equal(elem.outerHTML, '<div><!--a-->' +

--- a/test/lib/domComputed.ts
+++ b/test/lib/domComputed.ts
@@ -1,6 +1,8 @@
 import {dom} from '../../lib/dom';
-import {Disposable} from '../../lib/dispose';
-import {observable} from '../../lib/observable';
+import {Disposable, MultiHolder} from '../../lib/dispose';
+import {Computed} from '../../lib/computed';
+import {Observable, observable} from '../../lib/observable';
+// import {compute} from '../../lib/_computed_queue';
 import {assertResetSingleCall, useJsDomWindow} from './testutil2';
 
 import {assert} from 'chai';
@@ -110,5 +112,37 @@ describe("domComputed", function() {
     assertResetSingleCall(fooDispose, f3);
     sinon.assert.notCalled(fooConstruct);
     assert.equal(f3.isDisposed(), true);
+  });
+
+  it("should defer callback until the end of the compute loop", function() {
+    const owner = MultiHolder.create(null);
+    try {
+      class Foo extends Disposable {
+        public obs = Observable.create(this, "hello");
+        public comp = Computed.create(this, use => use(this.obs) + "-" + this.label);
+        constructor(public label: string) {
+          super();
+          assert.equal(this.comp.get(), "hello-" + this.label);
+          this.obs.set("world");
+          assert.equal(this.comp.get(), "world-" + this.label);
+        }
+        public buildDom() {
+          return this.comp.get();
+        }
+      }
+      const show = Observable.create(owner, false);
+      const elem = dom('div', 'Hello',
+        dom.maybe(show, () => dom.create(Foo, "direct")),
+        dom.maybe(use => use(show), () => dom.create(Foo, "indirect")),
+      );
+      show.set(true);
+      assert.equal(elem.innerHTML, `\
+Hello\
+<!--a--><!--a-->world-direct<!--b--><!--b-->\
+<!--a--><!--a-->world-indirect<!--b--><!--b-->\
+`);
+    } finally {
+      owner.dispose();
+    }
   });
 });

--- a/test/types/kowrap.ts
+++ b/test/types/kowrap.ts
@@ -3,7 +3,7 @@
  */
 import { expectType } from 'tsd';
 import { BindableValue, Computed, fromKo, Observable, subscribe, subscribeBindable } from '../../index';
-import { IKnockoutObservable, toKo, UseCBOwner } from '../../index';
+import { IKnockoutObservable, toKo, UseCB } from '../../index';
 import * as ko from 'knockout';
 
 const kObs = ko.observable("foo");
@@ -34,8 +34,8 @@ const bindable: BindableValue<string> = kObs;
 subscribeBindable(bindable, (val) => expectType<string>(val));
 subscribeBindable(gObs, (val) => expectType<string>(val));
 subscribeBindable((use) => {
-  expectType<UseCBOwner>(use);
+  expectType<UseCB>(use);
   return "foo";
 }, (val) => {
-  expectType<string>(val)
+  expectType<string>(val);
 });


### PR DESCRIPTION
If during the calculation of a computed, another observable gets set, then computeds that depend on it would not be
recalculated immediately -- because their recalculation is queued up to be handled by the outer calculation.

This is considered acceptable, because computed callbacks have no business explicitly setting observables: that would make correct and efficient dependency tracking impossible no matter what.

But inside a `dom.maybe` or `dom.domComputed`, it's quite normal to create new components, which normally create observables and computeds, and when the behavior described is encountered, it feels broken.

The fix is to split the recalculation queue into just computeds and everything else. Everything else is subscriptions which can't be depended on by other subscriptions. The calculation of dom bindings, including `dom.maybe` and `dom.domComputed`, falls into these "other subscriptions" category, and would now happen always after the computed queue, and outside of its bundling.

The new calculation flow is:
- Go through all enqueued computeds. Any recalculation queued up during this process is deferred to the outer loop.
- Go through "other subscriptions" (e.g. dom bindings).
  - Any recalculation of computeds queued up during this process is immediate.
  - Any other subscriptions queued up during this process (e.g. dom bindings) are deferred to the outer loop.

This involves a change to the behavior of dom binding that uses a `UseCB` function (e.g. `dom.hide(use => ...)`) to use `subscribe` rather than a computed with a low-level `addListener` to ensure it participates in the queue-scheduling described.